### PR TITLE
Make sure initial move is executed for calling the sub. 

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1057,6 +1057,10 @@ int Interp::convert_g7x(int mode,
     original_block.x_number=x;
     original_block.z_number=z;
 
+    int error=convert_straight(G_0, block, settings);
+    if(error!=INTERP_OK)
+	return error;
+
     g7x path;
     std::complex<double> start(z,x);
 


### PR DESCRIPTION
This allows the sub to use #<_Z> and #<_X> to find the initial position.